### PR TITLE
Add `await` to delivery of asynchronous updates to slack messages

### DIFF
--- a/lib/handle-app-mention.ts
+++ b/lib/handle-app-mention.ts
@@ -41,12 +41,12 @@ export async function handleNewAppMention(
   if (thread_ts) {
     const messages = await getThread(channel, thread_ts, botUserId);
     const result = await generateResponse(messages, updateMessage);
-    updateMessage(result);
+    await updateMessage(result);
   } else {
     const result = await generateResponse(
       [{ role: "user", content: event.text }],
       updateMessage,
     );
-    updateMessage(result);
+    await updateMessage(result);
   }
 }

--- a/lib/handle-messages.ts
+++ b/lib/handle-messages.ts
@@ -48,7 +48,7 @@ export async function handleNewAssistantMessage(
 
   const { thread_ts, channel } = event;
   const updateStatus = updateStatusUtil(channel, thread_ts);
-  updateStatus("is thinking...");
+  await updateStatus("is thinking...");
 
   const messages = await getThread(channel, thread_ts, botUserId);
   const result = await generateResponse(messages, updateStatus);
@@ -69,5 +69,5 @@ export async function handleNewAssistantMessage(
     ],
   });
 
-  updateStatus("");
+  await updateStatus("");
 }


### PR DESCRIPTION
Previously, some updates to the status and delivery of messages were not awaited. This would cause the responses from the AI tool to never be delivered, or be delivered very late to the slack client.

This change ensures asynchronous operations are properly handled by awaiting their completion which guarantees the delivery of most messages produced within a reasonable amount of time. (My tools answer in about 10s or less).

If you have tools that takes much longer, your experience may vary. 

This should fix https://github.com/vercel-labs/ai-sdk-slackbot/issues/2 or at least improve it.