### PR TITLE
Fix wrong bot event used in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Go to your [Slack App settings](https://api.slack.com/apps)
 - Under "Subscribe to bot events", add:
   - `app_mention`
   - `assistant_thread_started`
-  - `message:im`
+  - `message.im`
 
 > Remember to include `/api/events` in the Request URL.
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file to correct the event name format for Slack App settings.

Incorrect: `message:im`
Correct: `message.im`